### PR TITLE
Add a correct_and_deposit_fee_without_refund

### DIFF
--- a/infrablockspace/runtime/parachains/src/system_token_manager.rs
+++ b/infrablockspace/runtime/parachains/src/system_token_manager.rs
@@ -23,6 +23,7 @@ pub use frame_support::{
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use pallet_asset_link::AssetIdOf;
+pub use pallet_assets::types::BASE_SYSTEM_TOKEN_WEIGHT;
 use sp_runtime::{
 	traits::StaticLookup,
 	types::{
@@ -32,7 +33,6 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 use types::*;
-pub use pallet_assets::types::BASE_SYSTEM_TOKEN_WEIGHT;
 
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {

--- a/substrate/frame/assets/src/types.rs
+++ b/substrate/frame/assets/src/types.rs
@@ -39,7 +39,8 @@ pub const BASE_SYSTEM_TOKEN_WEIGHT: SystemTokenWeight = 1_000_000;
 
 pub(super) const CORRECTION_PARA_FEE_RATE: u128 = 1_000_000;
 
-/// Correction constant for converting the actual gas fee of ``asset_transfer` which is same with 0.05 iUSD
+/// Correction constant for converting the actual gas fee of ``asset_transfer` which is same with
+/// 0.05 iUSD
 pub(super) const CORRECTION_GAS_FEE: u128 = 25;
 
 /// AssetStatus holds the current state of the asset. It could either be Live and available for use,

--- a/substrate/frame/support/src/traits/tokens/fungibles/imbalance.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/imbalance.rs
@@ -159,6 +159,24 @@ impl<
 	}
 }
 
+// function to split Imbalance with no refund
+pub fn split_no_refund<A, B, OnDrop, OppositeOnDrop>(
+	asset: A,
+	amount: B,
+) -> (Imbalance<A, B, OnDrop, OppositeOnDrop>, Imbalance<A, B, OnDrop, OppositeOnDrop>)
+where
+	A: AssetId,
+	B: Balance,
+	OnDrop: HandleImbalanceDrop<A, B>,
+	OppositeOnDrop: HandleImbalanceDrop<A, B>,
+{
+	let refund_amount = B::zero();
+
+	let first_imbalance = Imbalance::new(asset.clone(), amount);
+	let refund_imbalance = Imbalance::new(asset, refund_amount);
+	(first_imbalance, refund_imbalance)
+}
+
 /// Imbalance implying that the total_issuance value is less than the sum of all account balances.
 pub type Debt<AccountId, B> = Imbalance<
 	<B as Inspect<AccountId>>::AssetId,

--- a/substrate/frame/support/src/traits/tokens/fungibles/imbalance.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/imbalance.rs
@@ -109,6 +109,13 @@ impl<
 		sp_std::mem::forget(self);
 		(Imbalance::new(asset.clone(), first), Imbalance::new(asset, second))
 	}
+	pub fn split_no_refund(self, amount: B) -> (Self, Self) {
+		let first = amount;
+		let second = B::zero();
+		let asset = self.asset.clone();
+		sp_std::mem::forget(self);
+		(Imbalance::new(asset.clone(), first), Imbalance::new(asset, second))
+	}
 	pub fn merge(mut self, other: Self) -> Result<Self, (Self, Self)> {
 		if self.asset == other.asset {
 			self.amount = self.amount.saturating_add(other.amount);

--- a/substrate/frame/support/src/traits/tokens/fungibles/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/mod.rs
@@ -33,7 +33,7 @@ pub use hold::{
 	Balanced as BalancedHold, Inspect as InspectHold, Mutate as MutateHold,
 	Unbalanced as UnbalancedHold,
 };
-pub use imbalance::{Credit, Debt, HandleImbalanceDrop, Imbalance};
+pub use imbalance::{split_no_refund, Credit, Debt, HandleImbalanceDrop, Imbalance};
 pub use lifetime::{Create, Destroy};
 pub use regular::{
 	Balanced, DecreaseIssuance, Dust, IncreaseIssuance, Inspect, Mutate, Unbalanced,

--- a/substrate/frame/transaction-payment/system-token-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/system-token-tx-payment/src/lib.rs
@@ -280,24 +280,40 @@ where
 						call_metadata.pallet_name,
 						call_metadata.function_name,
 					);
-					// Actual fee will be based on 'fee table' or default calculation
-					let actual_fee: BalanceOf<T> =
+
+					let (actual_fee, converted_fee, converted_tip): (BalanceOf<T>, _, _) =
+						// `fee` will be calculated based on the 'fee table'.
+						// The fee will be directly applied to the `final_fee` without any refunds.
 						if let Some(fee) = T::FeeTableProvider::get_fee_from_fee_table(metadata) {
-							fee.into()
+							let (converted_fee, converted_tip) =
+								T::OnChargeSystemToken::correct_and_deposit_fee_without_refund(
+									&who,
+									info,
+									post_info,
+									fee.into(),
+									tip.into(),
+									already_withdrawn.into(),
+								)?;
+
+							(fee.into(), converted_fee, converted_tip)
 						} else {
-							pallet_transaction_payment::Pallet::<T>::compute_actual_fee(
-								len as u32, info, post_info, tip,
-							)
+							// The `fee` will be calculated according to the original fee calculation logic.
+							let actual_fee =
+								pallet_transaction_payment::Pallet::<T>::compute_actual_fee(
+									len as u32, info, post_info, tip,
+								);
+							let (converted_fee, converted_tip) =
+								T::OnChargeSystemToken::correct_and_deposit_fee(
+									&who,
+									info,
+									post_info,
+									actual_fee.into(),
+									tip.into(),
+									already_withdrawn.into(),
+								)?;
+							(actual_fee, converted_fee, converted_tip)
 						};
-					let (converted_fee, converted_tip) =
-						T::OnChargeSystemToken::correct_and_deposit_fee(
-							&who,
-							info,
-							post_info,
-							actual_fee.into(),
-							tip.into(),
-							already_withdrawn.into(),
-						)?;
+
 					let tip: Option<AssetBalanceOf<T>> =
 						if converted_tip.is_zero() { None } else { Some(converted_tip) };
 					// update_vote_info is only excuted when vote_info has some data


### PR DESCRIPTION
# Description
- issue: When setting a fee for a specific call in the Fee table higher than the benchmarked fee, there are instances where fees are not correctly applied.
- solution: implement a method within the Fee table logic to allow fee calculation without refunds.

# Changes
- add a `correct_and_deposit_fee_without_refund ` method to the `OnChargeSystemToken`
- add a `split_no_refund ` function to Imbalance 