### PR TITLE
feat: 🎸 add check parachain in token aggregator

### DIFF
--- a/cumulus/infra-parachain/src/command.rs
+++ b/cumulus/infra-parachain/src/command.rs
@@ -102,7 +102,8 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		)?),
 		"contracts-hub-infra-dev" =>
 			Box::new(chain_spec::contracts::contracts_infra_development_config()),
-		"contracts-hub-infra-local" => Box::new(chain_spec::contracts::contracts_infra_local_config()),
+		"contracts-hub-infra-local" =>
+			Box::new(chain_spec::contracts::contracts_infra_local_config()),
 		"contracts-hub-infra" => Box::new(chain_spec::contracts::contracts_infra_config()),
 		// ToDo: chain-spec file for `ContractsInfra`
 		"did-hub-infra-dev" => Box::new(chain_spec::did::did_development_config()),

--- a/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
@@ -623,14 +623,14 @@ parameter_types! {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
-	pub const IsPara: bool = true;
+	pub const IsRelay: bool = false;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
-	type IsPara = IsPara;
+	type IsRelay = IsRelay;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
@@ -623,12 +623,14 @@ parameter_types! {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
+	pub const IsPara: bool = true;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
+	type IsPara = IsPara;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/cumulus/parachains/runtimes/contracts/contracts-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-infra/src/lib.rs
@@ -427,12 +427,14 @@ impl pallet_asset_link::Config for Runtime {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
+	pub const IsPara: bool = true;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
+	type IsPara = IsPara;
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/contracts/contracts-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-infra/src/lib.rs
@@ -427,14 +427,14 @@ impl pallet_asset_link::Config for Runtime {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
-	pub const IsPara: bool = true;
+	pub const IsRelay: bool = false;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
-	type IsPara = IsPara;
+	type IsRelay = IsRelay;
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/did/src/lib.rs
+++ b/cumulus/parachains/runtimes/did/src/lib.rs
@@ -665,14 +665,14 @@ parameter_types! {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
-	pub const IsPara: bool = true;
+	pub const IsRelay: bool = false;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
-	type IsPara = IsPara;
+	type IsRelay = IsRelay;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/cumulus/parachains/runtimes/did/src/lib.rs
+++ b/cumulus/parachains/runtimes/did/src/lib.rs
@@ -665,12 +665,14 @@ parameter_types! {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
+	pub const IsPara: bool = true;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
+	type IsPara = IsPara;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/cumulus/parachains/runtimes/ur-auth/src/lib.rs
+++ b/cumulus/parachains/runtimes/ur-auth/src/lib.rs
@@ -412,14 +412,14 @@ impl pallet_asset_link::Config for Runtime {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
-	pub const IsPara: bool = true;
+	pub const IsRelay: bool = false;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
-	type IsPara = IsPara;
+	type IsRelay = IsRelay;
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/ur-auth/src/lib.rs
+++ b/cumulus/parachains/runtimes/ur-auth/src/lib.rs
@@ -412,12 +412,14 @@ impl pallet_asset_link::Config for Runtime {
 
 parameter_types! {
 	pub const AggregatedPeriod: BlockNumber = 10;
+	pub const IsPara: bool = true;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = AggregatedPeriod;
 	type AssetMultiLocationGetter = AssetLink;
+	type IsPara = IsPara;
 }
 
 parameter_types! {

--- a/infrablockspace/runtime/infra-relay/src/lib.rs
+++ b/infrablockspace/runtime/infra-relay/src/lib.rs
@@ -1345,12 +1345,14 @@ impl pallet_assets::Config for Runtime {
 
 parameter_types! {
 	pub const Period: BlockNumber = 10;
+	pub const IsPara: bool = false;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = Period;
 	type AssetMultiLocationGetter = AssetLink;
+	type IsPara = IsPara;
 }
 
 construct_runtime! {

--- a/infrablockspace/runtime/infra-relay/src/lib.rs
+++ b/infrablockspace/runtime/infra-relay/src/lib.rs
@@ -1345,14 +1345,14 @@ impl pallet_assets::Config for Runtime {
 
 parameter_types! {
 	pub const Period: BlockNumber = 10;
-	pub const IsPara: bool = false;
+	pub const IsRelay: bool = true;
 }
 
 impl system_token_aggregator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Period = Period;
 	type AssetMultiLocationGetter = AssetLink;
-	type IsPara = IsPara;
+	type IsRelay = IsRelay;
 }
 
 construct_runtime! {

--- a/infrablockspace/runtime/parachains/src/system_token_aggregator.rs
+++ b/infrablockspace/runtime/parachains/src/system_token_aggregator.rs
@@ -60,7 +60,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type Period: Get<BlockNumberFor<Self>>;
 		type AssetMultiLocationGetter: AssetMultiLocationGetter<AssetId>;
-		type IsPara: Get<bool>;
+		type IsRelay: Get<bool>;
 	}
 
 	#[pallet::event]
@@ -87,8 +87,8 @@ pub mod pallet {
 	{
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
 			if n % T::Period::get() == Zero::zero() {
-				let is_para = T::IsPara::get();
-				Self::do_aggregate_system_token(is_para);
+				let is_relay = T::IsRelay::get();
+				Self::do_aggregate_system_token(is_relay);
 				T::DbWeight::get().reads(3)
 			} else {
 				T::DbWeight::get().reads(0)
@@ -98,7 +98,7 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	pub(crate) fn do_aggregate_system_token(is_para: bool)
+	pub(crate) fn do_aggregate_system_token(is_relay: bool)
 	where
 		u32: From<BlockNumberFor<T>>,
 		<<T as frame_system::Config>::RuntimeOrigin as OriginTrait>::AccountId:
@@ -124,7 +124,7 @@ impl<T: Config> Pallet<T> {
 					fee_account.clone(),
 					amount,
 					asset_multilocation.clone(),
-					is_para,
+					is_relay,
 				);
 
 				Self::deposit_event(Event::<T>::SystemTokenAggregated {

--- a/infrablockspace/runtime/parachains/src/system_token_aggregator.rs
+++ b/infrablockspace/runtime/parachains/src/system_token_aggregator.rs
@@ -60,6 +60,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type Period: Get<BlockNumberFor<Self>>;
 		type AssetMultiLocationGetter: AssetMultiLocationGetter<AssetId>;
+		type IsPara: Get<bool>;
 	}
 
 	#[pallet::event]
@@ -86,7 +87,8 @@ pub mod pallet {
 	{
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
 			if n % T::Period::get() == Zero::zero() {
-				Self::do_aggregate_system_token();
+				let is_para = T::IsPara::get();
+				Self::do_aggregate_system_token(is_para);
 				T::DbWeight::get().reads(3)
 			} else {
 				T::DbWeight::get().reads(0)
@@ -96,7 +98,7 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	pub(crate) fn do_aggregate_system_token()
+	pub(crate) fn do_aggregate_system_token(is_para: bool)
 	where
 		u32: From<BlockNumberFor<T>>,
 		<<T as frame_system::Config>::RuntimeOrigin as OriginTrait>::AccountId:
@@ -122,6 +124,7 @@ impl<T: Config> Pallet<T> {
 					fee_account.clone(),
 					amount,
 					asset_multilocation.clone(),
+					is_para,
 				);
 
 				Self::deposit_event(Event::<T>::SystemTokenAggregated {

--- a/infrablockspace/runtime/parachains/src/system_token_helper.rs
+++ b/infrablockspace/runtime/parachains/src/system_token_helper.rs
@@ -106,7 +106,7 @@ pub fn do_teleport_asset<T>(
 	beneficiary: T::AccountId,
 	amount: &T::Balance,
 	asset_multi_loc: MultiLocation,
-	is_para: bool,
+	is_relay: bool,
 ) where
 	T: pallet_xcm::Config + pallet_assets::Config,
 	u32: From<BlockNumberFor<T>>,
@@ -118,7 +118,7 @@ pub fn do_teleport_asset<T>(
 		X3(Junction::Parachain(para_id), _, _) => *para_id,
 		_ => 1000,
 	};
-	let parents: u8 = if is_para { 1 } else { 0 };
+	let parents: u8 = if is_relay { 0 } else { 1 };
 	let _ = pallet_xcm::Pallet::<T>::limited_teleport_assets(
 		<T as frame_system::Config>::RuntimeOrigin::signed(beneficiary.clone().into()),
 		Box::new(xcm::VersionedMultiLocation::V3(MultiLocation {

--- a/infrablockspace/runtime/parachains/src/system_token_helper.rs
+++ b/infrablockspace/runtime/parachains/src/system_token_helper.rs
@@ -106,6 +106,7 @@ pub fn do_teleport_asset<T>(
 	beneficiary: T::AccountId,
 	amount: &T::Balance,
 	asset_multi_loc: MultiLocation,
+	is_para: bool,
 ) where
 	T: pallet_xcm::Config + pallet_assets::Config,
 	u32: From<BlockNumberFor<T>>,
@@ -117,10 +118,11 @@ pub fn do_teleport_asset<T>(
 		X3(Junction::Parachain(para_id), _, _) => *para_id,
 		_ => 1000,
 	};
+	let parents: u8 = if is_para { 1 } else { 0 };
 	let _ = pallet_xcm::Pallet::<T>::limited_teleport_assets(
 		<T as frame_system::Config>::RuntimeOrigin::signed(beneficiary.clone().into()),
 		Box::new(xcm::VersionedMultiLocation::V3(MultiLocation {
-			parents: 1,
+			parents,
 			interior: X1(Junction::Parachain(dest_para_id)),
 		})),
 		Box::new(


### PR DESCRIPTION
# Overview

- Check parachain in token aggregator

# Changes

```rust
pub fn do_teleport_asset<T>(
	beneficiary: T::AccountId,
	amount: &T::Balance,
	asset_multi_loc: MultiLocation,
	is_para: bool,
) where
	T: pallet_xcm::Config + pallet_assets::Config,
	u32: From<BlockNumberFor<T>>,
	<<T as frame_system::Config>::RuntimeOrigin as OriginTrait>::AccountId: From<AccountIdOf<T>>,
	[u8; 32]: From<<T as frame_system::Config>::AccountId>,
	u128: From<<T as pallet_assets::Config>::Balance>,
{
        /* snip */
	let parents: u8 = if is_para { 1 } else { 0 };
	let _ = pallet_xcm::Pallet::<T>::limited_teleport_assets(
		<T as frame_system::Config>::RuntimeOrigin::signed(beneficiary.clone().into()),
		Box::new(xcm::VersionedMultiLocation::V3(MultiLocation {
			parents,
			interior: X1(Junction::Parachain(dest_para_id)),
		})),
		Box::new(
			Junction::AccountId32 { network: None, id: beneficiary.clone().into() }
				.into_location()
				.into(),
		),
		Box::new(
			MultiAsset { id: Concrete(asset_multi_loc), fun: Fungible(amount.clone().into()) }
				.into(),
		),
		0,
		xcm::v3::WeightLimit::Unlimited,
	);
}

```