### PR TITLE
hotfix: seed trust shouldn't be voted

### DIFF
--- a/infrablockspace/node/service/src/chain_spec.rs
+++ b/infrablockspace/node/service/src/chain_spec.rs
@@ -294,8 +294,8 @@ fn infra_relay_staging_testnet_config_genesis(
 		xcm_pallet: Default::default(),
 		validator_election: infra_relay::ValidatorElectionConfig {
 			seed_trust_validators: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-			total_number_of_validators: 2,
-			number_of_seed_trust_validators: 2,
+			total_validator_slots: 2,
+			seed_trust_slots: 2,
 			..Default::default()
 		},
 	}
@@ -607,8 +607,8 @@ fn rococo_staging_testnet_config_genesis(
 		assigned_slots: Default::default(),
 		validator_election: rococo_runtime::ValidatorElectionConfig {
 			seed_trust_validators: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-			total_number_of_validators: 2,
-			number_of_seed_trust_validators: 2,
+			total_validator_slots: 2,
+			seed_trust_slots: 2,
 			..Default::default()
 		},
 	}
@@ -829,8 +829,8 @@ pub fn infra_relay_testnet_genesis(
 		xcm_pallet: Default::default(),
 		validator_election: infra_relay::ValidatorElectionConfig {
 			seed_trust_validators: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-			total_number_of_validators: 6,
-			number_of_seed_trust_validators: 6,
+			total_validator_slots: 6,
+			seed_trust_slots: 6,
 			..Default::default()
 		},
 	}
@@ -917,8 +917,8 @@ pub fn rococo_testnet_genesis(
 		assigned_slots: Default::default(),
 		validator_election: rococo_runtime::ValidatorElectionConfig {
 			seed_trust_validators: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-			total_number_of_validators: 2,
-			number_of_seed_trust_validators: 2,
+			total_validator_slots: 2,
+			seed_trust_slots: 2,
 			..Default::default()
 		},
 	}

--- a/infrablockspace/runtime/infra-relay/src/lib.rs
+++ b/infrablockspace/runtime/infra-relay/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("InfraRelayChain"),
 	impl_name: create_runtime_str!("InfraRelayChain"),
 	authoring_version: 0,
-	spec_version: 10000,
+	spec_version: 10001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 24,

--- a/substrate/frame/validator-election/src/impls.rs
+++ b/substrate/frame/validator-election/src/impls.rs
@@ -90,7 +90,7 @@ pub trait VotingInterface<T> {
 	fn update_vote_status(who: VoteAccountId, weight: VoteWeight);
 }
 
-impl<T: Config> VotingInterface<T> for Pallet<T> 
+impl<T: Config> VotingInterface<T> for Pallet<T>
 where
 	T::AccountId: From<VoteAccountId>,
 {
@@ -238,10 +238,7 @@ impl<T: Config> Pallet<T> {
 		let mut maybe_new_validators: Vec<T::AccountId> =
 			Self::do_elect_seed_trust_validators(seed_trust_slots);
 		if Self::is_pot_enabled(num_pot) {
-			let mut pot_validators = Self::do_elect_pot_validators(
-				era_index, 
-				num_pot
-			);
+			let mut pot_validators = Self::do_elect_pot_validators(era_index, num_pot);
 			pot_enabled = true;
 			maybe_new_validators.append(&mut pot_validators);
 		}
@@ -310,22 +307,25 @@ impl<T: Config> Pallet<T> {
 		maybe_new_seed_trust_slots: Option<u32>,
 	) -> sp_runtime::DispatchResult {
 		let current_seed_trust_slots = SeedTrustSlots::<T>::get();
-		// 1. Check if 'new_total_slots' is smaller than 'current_seed_trust_slots', 'new_seed_trust_slots' should be provided
+		// 1. Check if 'new_total_slots' is smaller than 'current_seed_trust_slots',
+		//    'new_seed_trust_slots' should be provided
 		if new_total_slots < current_seed_trust_slots {
-			frame_support::ensure!(!maybe_new_seed_trust_slots.is_none(), Error::<T>::SeedTrustSlotsShouldBeProvided);
+			frame_support::ensure!(
+				!maybe_new_seed_trust_slots.is_none(),
+				Error::<T>::SeedTrustSlotsShouldBeProvided
+			);
 		}
 		// 2. Set 'total_validator_slots'
 		TotalValidatorSlots::<T>::put(new_total_slots);
-		Self::deposit_event(Event::<T>::TotalValidatorSlotsChanged {
-			new: new_total_slots,
-		});
+		Self::deposit_event(Event::<T>::TotalValidatorSlotsChanged { new: new_total_slots });
 		// 3. Do something if `new_seed_trust_slots` is provided
 		if let Some(new_seed_trust_slots) = maybe_new_seed_trust_slots {
-			frame_support::ensure!(new_total_slots >= new_seed_trust_slots, Error::<T>::SeedTrustExceedMaxValidators);
+			frame_support::ensure!(
+				new_total_slots >= new_seed_trust_slots,
+				Error::<T>::SeedTrustExceedMaxValidators
+			);
 			SeedTrustSlots::<T>::put(new_seed_trust_slots);
-			Self::deposit_event(Event::<T>::SeedTrustSlotsChanged {
-				new: new_seed_trust_slots,
-			});
+			Self::deposit_event(Event::<T>::SeedTrustSlotsChanged { new: new_seed_trust_slots });
 		}
 		Ok(())
 	}
@@ -333,7 +333,7 @@ impl<T: Config> Pallet<T> {
 	fn is_pot_enabled(num_pot: u32) -> bool {
 		if num_pot > 0 && Self::pool_status() == Pool::All {
 			return true
-		} 
+		}
 		false
 	}
 }

--- a/substrate/frame/validator-election/src/lib.rs
+++ b/substrate/frame/validator-election/src/lib.rs
@@ -205,8 +205,7 @@ pub mod pallet {
 			+ MaxEncodedLen
 			+ From<VoteWeight>;
 
-		/// Something that can estimate the next session change, accurately or as a best effort
-		/// guess.
+		/// Something that can estimate the next session change, accurately or as a best effort guess.
 		type NextNewSession: EstimateNextNewSession<BlockNumberFor<Self>>;
 
 		/// Interface for interacting with a session pallet.
@@ -222,8 +221,8 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub seed_trust_validators: Vec<T::AccountId>,
-		pub total_number_of_validators: u32,
-		pub number_of_seed_trust_validators: u32,
+		pub total_validator_slots: u32,
+		pub seed_trust_slots: u32,
 		pub force_era: Forcing,
 		pub pool_status: Pool,
 		pub is_pot_enable_at_genesis: bool,
@@ -234,9 +233,9 @@ pub mod pallet {
 		fn default() -> Self {
 			GenesisConfig {
 				is_pot_enable_at_genesis: false,
+				total_validator_slots: Default::default(),
 				seed_trust_validators: Default::default(),
-				total_number_of_validators: Default::default(),
-				number_of_seed_trust_validators: Default::default(),
+				seed_trust_slots: Default::default(),
 				force_era: Default::default(),
 				pool_status: Default::default(),
 				vote_status_at_genesis: Default::default(),
@@ -247,10 +246,10 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			assert!(self.total_number_of_validators <= self.number_of_seed_trust_validators);
+			assert!(self.seed_trust_slots <= self.total_validator_slots);
 			SeedTrustValidatorPool::<T>::put(self.seed_trust_validators.clone());
-			TotalNumberOfValidators::<T>::put(self.total_number_of_validators.clone());
-			NumberOfSeedTrustValidators::<T>::put(self.number_of_seed_trust_validators.clone());
+			TotalValidatorSlots::<T>::put(self.total_validator_slots.clone());
+			SeedTrustSlots::<T>::put(self.seed_trust_slots.clone());
 			ForceEra::<T>::put(self.force_era);
 			PoolStatus::<T>::put(self.pool_status);
 			if self.is_pot_enable_at_genesis {
@@ -270,9 +269,9 @@ pub mod pallet {
 		/// Points has been added for candidate validator
 		VotePointsAdded { who: T::InfraVoteAccountId },
 		/// Total number of validators has been changed
-		TotalValidatorsNumChanged { old: u32, new: u32 },
+		TotalValidatorSlotsChanged { new: u32 },
 		/// Number of seed trust validators has been changed
-		SeedTrustNumChanged { old: u32, new: u32 },
+		SeedTrustSlotsChanged { new: u32 },
 		/// Seed trust validator has been added to the pool
 		SeedTrustAdded { who: T::AccountId },
 		/// Validator have been elected
@@ -304,6 +303,8 @@ pub mod pallet {
 		SeedTrustExceedMaxValidators,
 		/// Some parameters for transaction are bad
 		BadTransactionParams,
+		/// New number of Seed Trust slots should be provided
+		SeedTrustSlotsShouldBeProvided
 	}
 
 	/// The current era index.
@@ -328,19 +329,19 @@ pub mod pallet {
 	#[pallet::unbounded]
 	pub type SeedTrustValidators<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
-	/// Validators which have been elected by PoT
+	/// Cuurent validators which have been elected by PoT
 	#[pallet::storage]
 	#[pallet::unbounded]
 	pub type PotValidators<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
 	/// Number of seed trust validators that can be elected
 	#[pallet::storage]
-	pub type NumberOfSeedTrustValidators<T: Config> = StorageValue<_, u32, ValueQuery>;
+	pub type SeedTrustSlots<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	/// Total Number of validators that can be elected,
 	/// which is composed of seed trust validators and pot validators
 	#[pallet::storage]
-	pub type TotalNumberOfValidators<T: Config> = StorageValue<_, u32, ValueQuery>;
+	pub type TotalValidatorSlots<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::storage]
 	pub type MinVotePointsThreshold<T: Config> = StorageValue<_, T::InfraVotePoints, ValueQuery>;
@@ -366,23 +367,14 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn set_number_of_validators(
 			origin: OriginFor<T>,
-			new_total: u32,
-			new_seed_trust_num: u32,
+			new_total_slots: u32,
+			new_seed_trust_slots: Option<u32>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			ensure!(new_total >= new_seed_trust_num, Error::<T>::SeedTrustExceedMaxValidators);
-			ensure!(
-				new_total >= T::SessionInterface::validators().len() as u32,
-				Error::<T>::LessThanCurrentValidatorsNum
-			);
-			let total_num = TotalNumberOfValidators::<T>::get();
-			let seed_trust_num = NumberOfSeedTrustValidators::<T>::get();
-			Self::do_set_number_of_validator(
-				total_num,
-				new_total,
-				seed_trust_num,
-				new_seed_trust_num,
-			);
+			Self::try_set_number_of_validator(
+				new_total_slots,
+				new_seed_trust_slots,
+			)?;
 
 			Ok(())
 		}

--- a/substrate/frame/validator-election/src/lib.rs
+++ b/substrate/frame/validator-election/src/lib.rs
@@ -205,7 +205,8 @@ pub mod pallet {
 			+ MaxEncodedLen
 			+ From<VoteWeight>;
 
-		/// Something that can estimate the next session change, accurately or as a best effort guess.
+		/// Something that can estimate the next session change, accurately or as a best effort
+		/// guess.
 		type NextNewSession: EstimateNextNewSession<BlockNumberFor<Self>>;
 
 		/// Interface for interacting with a session pallet.
@@ -304,7 +305,7 @@ pub mod pallet {
 		/// Some parameters for transaction are bad
 		BadTransactionParams,
 		/// New number of Seed Trust slots should be provided
-		SeedTrustSlotsShouldBeProvided
+		SeedTrustSlotsShouldBeProvided,
 	}
 
 	/// The current era index.
@@ -371,10 +372,7 @@ pub mod pallet {
 			new_seed_trust_slots: Option<u32>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			Self::try_set_number_of_validator(
-				new_total_slots,
-				new_seed_trust_slots,
-			)?;
+			Self::try_set_number_of_validator(new_total_slots, new_seed_trust_slots)?;
 
 			Ok(())
 		}

--- a/substrate/frame/validator-election/src/mock.rs
+++ b/substrate/frame/validator-election/src/mock.rs
@@ -1,15 +1,14 @@
-use crate::{self as pallet_infra_voting, *};
+use crate::{self as pallet_validator_election, *};
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild, Hooks, OneSessionHandler},
+	traits::{ConstU32, ConstU64, Hooks, OneSessionHandler},
 };
 use sp_core::{ByteArray, H256};
 use sp_keyring::Sr25519Keyring::*;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
 	types::{VoteAccountId, VoteWeight},
-	AccountId32,
+	AccountId32, BuildStorage
 };
 use std::collections::BTreeMap;
 
@@ -24,14 +23,11 @@ pub(crate) type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 frame_support::construct_runtime!(
-	pub enum TestRuntime where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+	pub enum TestRuntime 
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
-		InfraVoting: pallet_infra_voting::{Pallet, Call, Storage, Config<T>, Event<T>},
+		ValidatorElection: pallet_validator_election::{Pallet, Call, Storage, Config<T>, Event<T>},
 	}
 );
 
@@ -41,14 +37,13 @@ impl frame_system::Config for TestRuntime {
 	type BlockLength = ();
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
-	type Index = AccountIndex;
-	type BlockNumber = BlockNumber;
+	type Nonce = u64;
 	type RuntimeCall = RuntimeCall;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = ConstU64<250>;
 	type Version = ();
@@ -68,7 +63,7 @@ parameter_types! {
 	pub static SessionsPerEra: u32 = 5;
 }
 
-impl pallet_infra_voting::Config for TestRuntime {
+impl pallet_validator_election::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type SessionsPerEra = SessionsPerEra;
 	type InfraVoteAccountId = VoteAccountId;
@@ -146,7 +141,7 @@ impl pallet_session::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type Keys = SessionKeys;
 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-	type SessionManager = InfraVoting;
+	type SessionManager = ValidatorElection;
 	type SessionHandler = (OtherSessionHandler,);
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = TestValidatorIdOf;
@@ -167,7 +162,7 @@ impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
 			total_number_of_validators: 3,
-			number_of_seed_trust_validators: 3,
+			number_of_seed_trust_validators: 2,
 			seed_trust_validators: vec![],
 			initialize_first_session: true,
 			is_pot_enable_at_genesis: false,
@@ -222,16 +217,16 @@ impl ExtBuilder {
 
 	fn build(self) -> sp_io::TestExternalities {
 		let mut storage =
-			frame_system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
+			frame_system::GenesisConfig::<TestRuntime>::default().build_storage().unwrap();
 
 		let seed_trust_validators =
 			vec![Alice.to_account_id(), Bob.to_account_id(), Charlie.to_account_id()];
 		let account_keyring = vec![Alice, Bob, Charlie, Dave, Eve, Ferdie];
 
-		let _ = pallet_infra_voting::GenesisConfig::<TestRuntime> {
+		let _ = pallet_validator_election::GenesisConfig::<TestRuntime> {
 			seed_trust_validators: seed_trust_validators.clone(),
-			total_number_of_validators: self.total_number_of_validators,
-			number_of_seed_trust_validators: self.number_of_seed_trust_validators,
+			total_validator_slots: self.total_number_of_validators,
+			seed_trust_slots: self.number_of_seed_trust_validators,
 			is_pot_enable_at_genesis: self.is_pot_enable_at_genesis,
 			vote_status_at_genesis: self.vote_status,
 			..Default::default()
@@ -303,22 +298,21 @@ impl From<MockVoteStatus> for VotingStatus<TestRuntime> {
 impl MockVoteStatus {
 	fn create_mock_account(num: usize) -> Vec<VoteAccountId> {
 		let mut mock_accounts = vec![];
-		let accounts = vec![Dave, Ferdie, Eve];
+		let accounts = vec![Alice, Dave, Ferdie, Eve];
 		for i in 0..num {
 			mock_accounts.push(accounts[i].to_account_id());
 		}
 		mock_accounts
 	}
 
-	pub fn create_mock_pot(num: usize, is_over_min: bool) -> Self {
+	pub fn create_mock_pot(num: usize) -> Self {
 		let mut mock_pot = vec![];
 		let mock_accounts = Self::create_mock_account(num);
 		mock_accounts.into_iter().for_each(|acc| {
-			let min_threshold = MinVotePointsThreshold::get();
-			let vote_point = if !is_over_min && acc == Dave.to_account_id() {
-				min_threshold - 1
+			let vote_point = if acc == Dave.to_account_id() {
+				2
 			} else {
-				min_threshold + 1
+				3
 			};
 			mock_pot.push((acc, vote_point as VoteWeight));
 		});
@@ -335,14 +329,14 @@ impl MockVoteStatus {
 }
 /// There will be three candidates for testing
 /// Dave, Eve, Ferdie
-pub(crate) fn create_mock_vote_status(num: usize, is_over_min: bool) -> MockVoteStatus {
-	MockVoteStatus::create_mock_pot(num, is_over_min)
+pub(crate) fn create_mock_vote_status(num: usize) -> MockVoteStatus {
+	MockVoteStatus::create_mock_pot(num)
 }
 
-pub(crate) fn infra_voting_events() -> Vec<crate::Event<TestRuntime>> {
+pub(crate) fn validator_election_events() -> Vec<crate::Event<TestRuntime>> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| if let RuntimeEvent::InfraVoting(inner) = e { Some(inner) } else { None })
+		.filter_map(|e| if let RuntimeEvent::ValidatorElection(inner) = e { Some(inner) } else { None })
 		.collect()
 }

--- a/substrate/frame/validator-election/src/mock.rs
+++ b/substrate/frame/validator-election/src/mock.rs
@@ -8,7 +8,7 @@ use sp_keyring::Sr25519Keyring::*;
 use sp_runtime::{
 	traits::{BlakeTwo256, Convert, IdentityLookup},
 	types::{VoteAccountId, VoteWeight},
-	AccountId32, BuildStorage
+	AccountId32, BuildStorage,
 };
 use std::collections::BTreeMap;
 
@@ -23,7 +23,7 @@ pub(crate) type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 frame_support::construct_runtime!(
-	pub enum TestRuntime 
+	pub enum TestRuntime
 	{
 		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
@@ -309,11 +309,7 @@ impl MockVoteStatus {
 		let mut mock_pot = vec![];
 		let mock_accounts = Self::create_mock_account(num);
 		mock_accounts.into_iter().for_each(|acc| {
-			let vote_point = if acc == Dave.to_account_id() {
-				2
-			} else {
-				3
-			};
+			let vote_point = if acc == Dave.to_account_id() { 2 } else { 3 };
 			mock_pot.push((acc, vote_point as VoteWeight));
 		});
 		Self(mock_pot)
@@ -337,6 +333,8 @@ pub(crate) fn validator_election_events() -> Vec<crate::Event<TestRuntime>> {
 	System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| if let RuntimeEvent::ValidatorElection(inner) = e { Some(inner) } else { None })
+		.filter_map(
+			|e| if let RuntimeEvent::ValidatorElection(inner) = e { Some(inner) } else { None },
+		)
 		.collect()
 }


### PR DESCRIPTION
## Description
- Seed Trust 에 속한 계정은 투표 무효처리로 변경
- `paras-inclusion` 의 `VotingInterface::update_vote()` 로직 수정
- `NumberOf-*` 네이밍 변경

## Changes
- 변수명

| Prev | Change |
| - | - | 
| `TotalNumberOfValidators` | `TotalValidatorSlots` |
| `NumberOfSeedTrustValidator` | `SeedTrustSlots` |

- `VotingInterface` trait

```rust 
impl<T: Config> VotingInterface<T> for Pallet<T>
where
	T::AccountId: From<VoteAccountId>,
{
	fn update_vote_status(who: VoteAccountId, weight: VoteWeight) {
		if SeedTrustValidatorPool::<T>::get().contains(&who.clone().into()) {
			return
		}
            ...
	}
}
```

