### PR TITLE
Feature/41 kickout offline validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11617,6 +11617,7 @@ dependencies = [
  "pallet-assets",
  "pallet-authorship",
  "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -11626,6 +11627,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
+ "sp-staking",
  "sp-std 8.0.0",
  "sp-tracing 10.0.0",
 ]

--- a/cumulus/infra-assethub-parachain/Cargo.toml
+++ b/cumulus/infra-assethub-parachain/Cargo.toml
@@ -112,3 +112,4 @@ try-runtime = [
 	"infrablockchain-service/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+fast-runtime = ["asset-hub-runtime/fast-runtime"]

--- a/cumulus/infra-assethub-parachain/src/chain_spec/asset_hubs.rs
+++ b/cumulus/infra-assethub-parachain/src/chain_spec/asset_hubs.rs
@@ -189,6 +189,9 @@ fn asset_hub_genesis(
 	root_key: Option<AccountId>,
 	id: ParaId,
 ) -> asset_hub_runtime::RuntimeGenesisConfig {
+	#[cfg(feature = "fast-runtime")]
+	let root_key = get_account_id_from_seed::<sr25519::Public>("Alice");
+
 	asset_hub_runtime::RuntimeGenesisConfig {
 		system: asset_hub_runtime::SystemConfig {
 			code: asset_hub_runtime::WASM_BINARY
@@ -234,6 +237,7 @@ fn asset_hub_genesis(
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
 			..Default::default()
 		},
+		#[cfg(feature = "fast-runtime")]
 		sudo: asset_hub_runtime::SudoConfig { key: root_key },
 	}
 }

--- a/cumulus/infra-assethub-parachain/src/chain_spec/asset_hubs.rs
+++ b/cumulus/infra-assethub-parachain/src/chain_spec/asset_hubs.rs
@@ -183,15 +183,13 @@ pub fn asset_hub_config() -> AssetHubChainSpec {
 	)
 }
 
+#[allow(unused_variables)]
 fn asset_hub_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
 	root_key: Option<AccountId>,
 	id: ParaId,
 ) -> asset_hub_runtime::RuntimeGenesisConfig {
-	#[cfg(feature = "fast-runtime")]
-	let root_key = get_account_id_from_seed::<sr25519::Public>("Alice");
-
 	asset_hub_runtime::RuntimeGenesisConfig {
 		system: asset_hub_runtime::SystemConfig {
 			code: asset_hub_runtime::WASM_BINARY

--- a/cumulus/infra-parachain/src/chain_spec/asset_hubs.rs
+++ b/cumulus/infra-parachain/src/chain_spec/asset_hubs.rs
@@ -234,6 +234,7 @@ fn asset_hub_genesis(
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
 			..Default::default()
 		},
+		#[cfg(feature = "fast-runtime")]
 		sudo: asset_hub_runtime::SudoConfig { key: root_key },
 	}
 }

--- a/cumulus/infra-parachain/src/chain_spec/asset_hubs.rs
+++ b/cumulus/infra-parachain/src/chain_spec/asset_hubs.rs
@@ -183,6 +183,7 @@ pub fn asset_hub_config() -> AssetHubChainSpec {
 	)
 }
 
+#[allow(unused_variables)]
 fn asset_hub_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,

--- a/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
@@ -685,12 +685,19 @@ impl system_token_aggregator::Config for Runtime {
 	type SendXcm = XcmRouter;
 	type IsRelay = IsRelay;
 }
-
 #[cfg(feature = "fast-runtime")]
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type WeightInfo = ();
+}
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
+where
+	RuntimeCall: From<C>,
+{
+	type Extrinsic = UncheckedExtrinsic;
+	type OverarchingCall = RuntimeCall;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -733,9 +740,9 @@ construct_runtime!(
 		// The main stage.
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>, Config<T>} = 50,
 		Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 51,
-		AssetLink: pallet_asset_link = 52,
-		SystemTokenAggregator: system_token_aggregator = 53,
-		SystemToken: pallet_system_token = 54,
+		AssetLink: pallet_asset_link::{Pallet, Storage, Event<T>} = 52,
+		SystemTokenAggregator: system_token_aggregator = 54,
+		SystemTokenOracle: pallet_system_token_oracle::{Pallet, Call, Storage, ValidateUnsigned} = 55,
 
 		#[cfg(feature = "fast-runtime")]
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,

--- a/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-infra/src/lib.rs
@@ -686,18 +686,11 @@ impl system_token_aggregator::Config for Runtime {
 	type IsRelay = IsRelay;
 }
 
+#[cfg(feature = "fast-runtime")]
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type WeightInfo = ();
-}
-
-impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
-where
-	RuntimeCall: From<C>,
-{
-	type Extrinsic = UncheckedExtrinsic;
-	type OverarchingCall = RuntimeCall;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -740,10 +733,11 @@ construct_runtime!(
 		// The main stage.
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>, Config<T>} = 50,
 		Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 51,
-		AssetLink: pallet_asset_link::{Pallet, Storage, Event<T>} = 52,
-		SystemTokenAggregator: system_token_aggregator = 54,
-		SystemTokenOracle: pallet_system_token_oracle::{Pallet, Call, Storage, ValidateUnsigned} = 55,
+		AssetLink: pallet_asset_link = 52,
+		SystemTokenAggregator: system_token_aggregator = 53,
+		SystemToken: pallet_system_token = 54,
 
+		#[cfg(feature = "fast-runtime")]
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
 	}
 );

--- a/cumulus/zombienet/local-network.toml
+++ b/cumulus/zombienet/local-network.toml
@@ -1,5 +1,5 @@
 [relaychain]
-default_command = "../target/release/infra-relaychain"
+default_command = "./target/release/infra-relaychain"
 default_args = ["-lparachain=debug", "-l=xcm=trace"]
 chain = "infra-relay-local"
 
@@ -45,26 +45,26 @@ args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 7600
 ws_port = 7601
 
-[[parachains]]
-id = 1000
-chain = "asset-hub-infra-local"
-cumulus_based = true
+# [[parachains]]
+# id = 1000
+# chain = "asset-hub-infra-local"
+# cumulus_based = true
 
-[[parachains.collators]]
-name = "asset-hub-alice"
-validator = true
-args = ["-lparachain=debug", "-l=xcm=trace"]
-command = "../target/release/infra-parachain"
-rpc_port = 9500
-ws_port = 9501
+# [[parachains.collators]]
+# name = "asset-hub-alice"
+# validator = true
+# args = ["-lparachain=debug", "-l=xcm=trace"]
+# command = "../target/release/infra-parachain"
+# rpc_port = 9500
+# ws_port = 9501
 
-[[parachains.collators]]
-name = "asset-hub-bob"
-validator = true
-args = ["-lparachain=debug", "-l=xcm=trace"]
-command = "../target/release/infra-parachain"
-rpc_port = 9600
-ws_port = 9601
+# [[parachains.collators]]
+# name = "asset-hub-bob"
+# validator = true
+# args = ["-lparachain=debug", "-l=xcm=trace"]
+# command = "../target/release/infra-parachain"
+# rpc_port = 9600
+# ws_port = 9601
 
 # [[parachains]]
 # id = 1001
@@ -87,44 +87,44 @@ ws_port = 9601
 # rpc_port = 9800
 # ws_port = 9801
 
-# [[parachains]]
-# id = 1002
-# chain = "did-hub-infra-local"
-# cumulus_based = true
+[[parachains]]
+id = 1002
+chain = "did-hub-infra-local"
+cumulus_based = true
 
-# [[parachains.collators]]
-# name = "did-infra-alice"
-# validator = true
-# args = ["-lparachain=debug", "-l=xcm=trace"]
-# command = "../target/release/infra-parachain"
-# rpc_port = 9900
-# ws_port = 9901
+[[parachains.collators]]
+name = "did-infra-alice"
+validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
+command = "./target/release/infra-parachain"
+rpc_port = 9900
+ws_port = 9901
 
-# [[parachains.collators]]
-# name = "did-infra-bob"
-# validator = true
-# args = ["-lparachain=debug", "-l=xcm=trace"]
-# command = "../target/release/infra-parachain"
-# rpc_port = 10000
-# ws_port = 10001
+[[parachains.collators]]
+name = "did-infra-bob"
+validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
+command = "./target/release/infra-parachain"
+rpc_port = 10000
+ws_port = 10001
 
-# [[parachains]]
-# id = 2000
-# chain = "newnal-infra-local"
-# cumulus_based = true
+[[parachains]]
+id = 2000
+chain = "newnal-infra-local"
+cumulus_based = true
 
-# [[parachains.collators]]
-# name = "newnal-alice"
-# validator = true
-# args = ["-lparachain=debug", "-l=xcm=trace"]
-# command = "./target/release/infra-parachain"
-# rpc_port = 10100
-# ws_port = 10101
+[[parachains.collators]]
+name = "newnal-alice"
+validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
+command = "./target/release/infra-parachain"
+rpc_port = 10100
+ws_port = 10101
 
-# [[parachains.collators]]
-# name = "newnal-bob"
-# validator = true
-# args = ["-lparachain=debug", "-l=xcm=trace"]
-# command = "./target/release/infra-parachain"
-# rpc_port = 10200
-# ws_port = 10201
+[[parachains.collators]]
+name = "newnal-bob"
+validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
+command = "./target/release/infra-parachain"
+rpc_port = 10200
+ws_port = 10201

--- a/infrablockchain/runtime/infra-relay/src/lib.rs
+++ b/infrablockchain/runtime/infra-relay/src/lib.rs
@@ -771,7 +771,7 @@ impl pallet_tips::Config for Runtime {
 impl pallet_offences::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
-	type OnOffenceHandler = ();
+	type OnOffenceHandler = ValidatorElection;
 }
 
 impl pallet_authority_discovery::Config for Runtime {

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -30,7 +30,6 @@ sp-io = { path = "../../primitives/io", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
 sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"] }
 sp-std = { path = "../../primitives/std", default-features = false }
-# pallet-validator-election = { path = "../validator-election", default-features = false }
 
 [dev-dependencies]
 pallet-session = { path = "../session" }
@@ -45,7 +44,6 @@ std = [
 	"log/std",
 	"pallet-authorship/std",
 	"pallet-session/std",
-	# "pallet-validator-election/std",
 	"scale-info/std",
 	"sp-application-crypto/std",
 	"sp-core/std",

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -13,25 +13,30 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+	"derive",
+] }
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
-frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
-frame-support = { path = "../support", default-features = false}
-frame-system = { path = "../system", default-features = false}
-pallet-authorship = { path = "../authorship", default-features = false}
-sp-application-crypto = { path = "../../primitives/application-crypto", default-features = false, features = ["serde"] }
+frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
+frame-support = { path = "../support", default-features = false }
+frame-system = { path = "../system", default-features = false }
+pallet-authorship = { path = "../authorship", default-features = false }
+sp-application-crypto = { path = "../../primitives/application-crypto", default-features = false, features = [
+	"serde",
+] }
 sp-core = { path = "../../primitives/core", default-features = false, features = ["serde"] }
-sp-io = { path = "../../primitives/io", default-features = false}
+sp-io = { path = "../../primitives/io", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
 sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"] }
-sp-std = { path = "../../primitives/std", default-features = false}
+sp-std = { path = "../../primitives/std", default-features = false }
+# pallet-validator-election = { path = "../validator-election", default-features = false }
 
 [dev-dependencies]
 pallet-session = { path = "../session" }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
 	"codec/std",
 	"frame-benchmarking?/std",
@@ -40,6 +45,7 @@ std = [
 	"log/std",
 	"pallet-authorship/std",
 	"pallet-session/std",
+	# "pallet-validator-election/std",
 	"scale-info/std",
 	"sp-application-crypto/std",
 	"sp-core/std",

--- a/substrate/frame/im-online/src/lib.rs
+++ b/substrate/frame/im-online/src/lib.rs
@@ -96,7 +96,6 @@ use frame_system::{
 	pallet_prelude::*,
 };
 pub use pallet::*;
-// use pallet_validator_election::OnOffenceHandler;
 use scale_info::TypeInfo;
 use sp_application_crypto::RuntimeAppPublic;
 use sp_runtime::{
@@ -306,8 +305,6 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
-
-		// type OnOffenceHandler: OnOffenceHandler<Self::AccountId>;
 	}
 
 	#[pallet::event]
@@ -794,17 +791,6 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 			})
 			.collect::<Vec<IdentificationTuple<T>>>();
 
-		// let offenders2 = current_validators
-		// 	.into_iter()
-		// 	.enumerate()
-		// 	.filter(|(index, _id)| !Self::is_online_aux(*index as u32, _id))
-		// 	.map(|(_, id)| {
-		// 		// Assuming ValidatorId<T> can be directly converted to T::AccountId
-		// 		let account_id: T::AccountId = id.into();
-		// 		account_id
-		// 	})
-		// 	.collect::<Vec<T::AccountId>>();
-
 		// Remove all received heartbeats and number of authored blocks from the
 		// current session, they have already been processed and won't be needed
 		// anymore.
@@ -817,7 +803,6 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 			Self::deposit_event(Event::<T>::AllGood);
 		} else {
 			Self::deposit_event(Event::<T>::SomeOffline { offline: offenders.clone() });
-			// T::OnOffenceHandler::punish_validators(offenders2);
 
 			let validator_set_count = keys.len() as u32;
 			let offence = UnresponsivenessOffence { session_index, validator_set_count, offenders };

--- a/substrate/frame/im-online/src/lib.rs
+++ b/substrate/frame/im-online/src/lib.rs
@@ -780,7 +780,6 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 		let current_validators = T::ValidatorSet::validators();
 
 		let offenders = current_validators
-			.clone()
 			.into_iter()
 			.enumerate()
 			.filter(|(index, id)| !Self::is_online_aux(*index as u32, id))

--- a/substrate/frame/validator-election/Cargo.toml
+++ b/substrate/frame/validator-election/Cargo.toml
@@ -22,6 +22,7 @@ scale-info = { version = "2.5.0", default-features = false, features = ["derive"
 softfloat = { path = "../../primitives/softfloat", default-features = false }
 
 # primitives
+sp-staking = { path = "../../../substrate/primitives/staking", default-features = false }
 sp-application-crypto = { path = "../../primitives/application-crypto", default-features = false }
 sp-core = { path = "../../../substrate/primitives/core", default-features = false }
 sp-io = { path = "../../../substrate/primitives/io", default-features = false }
@@ -35,6 +36,7 @@ frame-system = { path = "../system", default-features = false }
 pallet-authorship = { path = "../authorship", default-features = false }
 pallet-assets = { path = "../assets", default-features = false }
 pallet-session = { path = "../session", default-features = false }
+pallet-staking = { path = "../staking", default-features = false }
 
 
 [dev-dependencies]
@@ -59,4 +61,5 @@ std = [
 	"pallet-authorship/std",
 	"pallet-assets/std",
 	"pallet-session/std",
+	"pallet-staking/std",
 ]

--- a/substrate/frame/validator-election/src/impls.rs
+++ b/substrate/frame/validator-election/src/impls.rs
@@ -420,10 +420,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> Pallet<T>
-where
-	T: pallet::Config<InfraVoteAccountId = <T as frame_system::Config>::AccountId>,
-{
+impl<T: Config> Pallet<T> {
 	pub fn do_restore_kicked_out_validator(who: T::AccountId) -> DispatchResult {
 		let mut kicked_out_validators = KickedOutValidators::<T>::get();
 		let mut seed_trust_validator_pool = SeedTrustValidatorPool::<T>::get();
@@ -440,7 +437,7 @@ where
 					SeedTrustValidatorPool::<T>::put(seed_trust_validator_pool);
 				},
 				ValidatorType::Pot(_, points) => {
-					pot_validator_pool.push((who.clone(), points));
+					pot_validator_pool.push((who.clone().into(), points));
 					PotValidatorPool::<T>::put(VotingStatus { status: pot_validator_pool });
 				},
 			}

--- a/substrate/frame/validator-election/src/impls.rs
+++ b/substrate/frame/validator-election/src/impls.rs
@@ -8,9 +8,9 @@ use sp_staking::{
 	EraIndex, SessionIndex,
 };
 
-use pallet_staking::{BalanceOf, Exposure, ExposureOf};
-
 use crate::*;
+
+use sp_runtime::DispatchResult;
 
 pub trait CollectiveInterface<AccountId> {
 	fn set_new_members(new: Vec<AccountId>);
@@ -95,19 +95,12 @@ impl<AccountId> SessionInterface<AccountId> for () {
 	}
 }
 
-// pub trait OnOffenceHandler<AccountId> {
-// 	fn on_offence(offenders: Vec<AccountId>);
-// }
-
-impl<T: Config + pallet_staking::Config>
+impl<T: Config + pallet_session::historical::Config>
 	OnOffenceHandler<T::AccountId, pallet_session::historical::IdentificationTuple<T>, Weight>
 	for Pallet<T>
 where
+	T: pallet::Config<InfraVoteAccountId = <T as frame_system::Config>::AccountId>,
 	T: pallet_session::Config<ValidatorId = <T as frame_system::Config>::AccountId>,
-	T: pallet_session::historical::Config<
-		FullIdentification = Exposure<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
-		FullIdentificationOf = ExposureOf<T>,
-	>,
 	T::SessionHandler: pallet_session::SessionHandler<<T as frame_system::Config>::AccountId>,
 	T::SessionManager: pallet_session::SessionManager<<T as frame_system::Config>::AccountId>,
 	T::ValidatorIdOf: Convert<
@@ -124,26 +117,47 @@ where
 		_slash_session: SessionIndex,
 		_disable_strategy: DisableStrategy,
 	) -> Weight {
+		let mut consumed_weight = Weight::from_parts(0, 0);
+		let mut add_db_reads_writes = |reads, writes| {
+			consumed_weight += T::DbWeight::get().reads_writes(reads, writes);
+		};
+
 		let mut old_kicked_out_validators = KickedOutValidators::<T>::get();
 		let mut seed_trust_validators = SeedTrustValidators::<T>::get();
+		let mut seed_trust_validator_pool = SeedTrustValidatorPool::<T>::get();
 		let mut pot_validators = PotValidators::<T>::get();
+		let mut pot_validator_pool = PotValidatorPool::<T>::get().status;
+		add_db_reads_writes(5, 0);
 
 		for offence_detail in offenders {
-			let offender = &offence_detail.offender.0;
-			// Add to kicked out validators if not already present
-			if !old_kicked_out_validators.contains(&offender) {
-				old_kicked_out_validators.push(offender.clone());
+			let offender: &T::InfraVoteAccountId = &offence_detail.offender.0.clone().into();
+
+			if !old_kicked_out_validators.iter().any(|v| match v {
+				ValidatorType::SeedTrust(account) | ValidatorType::Pot(account, _) =>
+					account == offender,
+			}) {
+				if let Some((_, points)) =
+					pot_validator_pool.iter().find(|(account, _)| account == offender)
+				{
+					old_kicked_out_validators.push(ValidatorType::Pot(offender.clone(), *points));
+				} else {
+					old_kicked_out_validators.push(ValidatorType::SeedTrust(offender.clone()));
+				}
 			}
 
-			// Remove from SeedTrustValidators and PotValidators if present
 			seed_trust_validators.retain(|validator| validator != offender);
+			seed_trust_validator_pool.retain(|validator| validator != offender);
 			pot_validators.retain(|validator| validator != offender);
+			pot_validator_pool.retain(|(validator, _)| validator != offender);
 		}
 
 		KickedOutValidators::<T>::put(old_kicked_out_validators);
 		SeedTrustValidators::<T>::put(seed_trust_validators);
+		SeedTrustValidatorPool::<T>::put(seed_trust_validator_pool);
 		PotValidators::<T>::put(pot_validators);
-		let consumed_weight = Weight::from_parts(0, 0);
+		PotValidatorPool::<T>::put(VotingStatus { status: pot_validator_pool });
+		add_db_reads_writes(5, 5);
+
 		consumed_weight
 	}
 }
@@ -374,7 +388,7 @@ impl<T: Config> Pallet<T> {
 	pub fn try_set_number_of_validator(
 		new_total_slots: u32,
 		maybe_new_seed_trust_slots: Option<u32>,
-	) -> sp_runtime::DispatchResult {
+	) -> DispatchResult {
 		let current_seed_trust_slots = SeedTrustSlots::<T>::get();
 		// 1. Check if 'new_total_slots' is smaller than 'current_seed_trust_slots',
 		//    'new_seed_trust_slots' should be provided
@@ -404,5 +418,40 @@ impl<T: Config> Pallet<T> {
 			return true
 		}
 		false
+	}
+}
+
+impl<T: Config> Pallet<T>
+where
+	T: pallet::Config<InfraVoteAccountId = <T as frame_system::Config>::AccountId>,
+{
+	pub fn do_restore_kicked_out_validator(who: T::AccountId) -> DispatchResult {
+		let mut kicked_out_validators = KickedOutValidators::<T>::get();
+		let mut seed_trust_validator_pool = SeedTrustValidatorPool::<T>::get();
+		let mut pot_validator_pool = PotValidatorPool::<T>::get().status;
+
+		let validator_position = kicked_out_validators.iter().position(|v| match v {
+			ValidatorType::SeedTrust(account) | ValidatorType::Pot(account, _) => account == &who,
+		});
+
+		if let Some(pos) = validator_position {
+			match kicked_out_validators[pos].clone() {
+				ValidatorType::SeedTrust(_) => {
+					seed_trust_validator_pool.push(who.clone());
+					SeedTrustValidatorPool::<T>::put(seed_trust_validator_pool);
+				},
+				ValidatorType::Pot(_, points) => {
+					pot_validator_pool.push((who.clone(), points));
+					PotValidatorPool::<T>::put(VotingStatus { status: pot_validator_pool });
+				},
+			}
+
+			kicked_out_validators.remove(pos);
+			KickedOutValidators::<T>::put(kicked_out_validators);
+
+			Ok(())
+		} else {
+			Err(Error::<T>::NotFoundKickedOutValidators.into())
+		}
 	}
 }

--- a/substrate/frame/validator-election/src/lib.rs
+++ b/substrate/frame/validator-election/src/lib.rs
@@ -401,10 +401,7 @@ pub mod pallet {
 	}
 
 	#[pallet::call]
-	impl<T: Config> Pallet<T>
-	where
-		T: pallet::Config<InfraVoteAccountId = <T as frame_system::Config>::AccountId>,
-	{
+	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn set_number_of_validators(


### PR DESCRIPTION
# Overview
- Validator가 Offline 등의 offence를 범했을 때 active set에서 kickout되는 기능 추가 
- kickouted validator는 validator로의 복구를 제안할 수 있으며, 결과는 governance에 의해 결정됨

# Changes
### offender kick-out & restore 과정
1) im-online pallet에 구현된 on_before_session_ending을 통해 offender가 있을 경우 report_offence가 실행
```rust
if offenders.is_empty() {
	Self::deposit_event(Event::<T>::AllGood);
} else {
	Self::deposit_event(Event::<T>::SomeOffline { offline: offenders.clone() });

	let validator_set_count = keys.len() as u32;
	let offence = UnresponsivenessOffence { session_index, validator_set_count, offenders };
	if let Err(e) = T::ReportUnresponsiveness::report_offence(vec![], offence) {
		sp_runtime::print(e);
	}
}
```
2) offence pallet의 OnOffenceHandler trait에 구현된 on_offence() 호출 
```
impl ReportOffence for Pallet<T> {
	fn report_offence() {
		..
		T::OnOffenceHandler::on_offence();
	}
}
```
3) validator-election pallet에 OnOffenceHandler를 추가하여 Validator pool & set, kickouted set 관리
- kick-out 구현: OnOffenceHandler::on_offence()
- restore 구현
  - kickouted validator는 `fn restore_kicked_out_validator`을 통해 validator set으로의 복구를 소명할 수 있음
  - Pot Validator가 복원될 경우, 기존에 투표 받은 vote points도 함께 복구

# Related Issues
Closed #41 

# Reference
- @cocoyoon 이 작성한 [노션](https://www.notion.so/Penalty-63deb59d72ab4a90a4e85812ab47a016?pvs=4) 참고